### PR TITLE
[IS_7]fixed camera namespace

### DIFF
--- a/Erbium/Assets/Scripts/Camera/CameraManager.cs
+++ b/Erbium/Assets/Scripts/Camera/CameraManager.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEngine;
 
-namespace Camera
+namespace ErbiumCamera
 {
     public class CameraManager : MonoBehaviour
     {

--- a/Erbium/Assets/Scripts/Player/MovementDirection/ThirdPersonCameraDirection.cs
+++ b/Erbium/Assets/Scripts/Player/MovementDirection/ThirdPersonCameraDirection.cs
@@ -1,4 +1,4 @@
-﻿using Camera;
+﻿using ErbiumCamera;
 using General;
 using UnityEngine;
 


### PR DESCRIPTION
Changed camera namespace from `Camera` to `ErbiumCamera` so it won't make problems with the Camera namespace from Unity



Closes [this issue](https://github.com/mikhomak/Erbium/issues/7)